### PR TITLE
Skip calling Windows console api with piped stdin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,8 @@ environment:
   - TARGET: x86_64-pc-windows-gnu
   - TARGET: i686-pc-windows-gnu
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.33.0-${env:TARGET}.exe"
-  - rust-1.33.0-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-1.44.0-${env:TARGET}.exe"
+  - rust-1.44.0-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
   - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V

--- a/tests/piped.rs
+++ b/tests/piped.rs
@@ -1,0 +1,35 @@
+//! This test checks that piped input is handled correctly.
+
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn piped_password() {
+    // Find target directory
+    let target_dir = env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+
+    // Run an example that reads a password and prints it
+    let mut out = Command::new(target_dir.join("examples/read-password"))
+        .stdout(Stdio::piped())
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    
+    // Write "secret" as the password into stdin
+    let stdin = out.stdin.as_mut().unwrap();
+    stdin.write_all("secret".as_bytes()).unwrap();
+
+    let out = out.wait_with_output().unwrap();
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    println!("stdout: {}", stdout);
+    assert!(stdout.ends_with("Password: secret\n"));
+}


### PR DESCRIPTION
Fixes #50 

I implemented the changes discussed in the issue. I also wrote a test that fails on Windows in the current master branch and passes after the changes, but it feels a bit hacky as it just runs one of the examples...