### PR TITLE
Bump to v5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,3 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["std", "winnt", "fileapi", "processenv", "winbase", "handleapi", "consoleapi", "minwindef", "wincon"] }
-
-[features]
-enhanced_mock = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rpassword"
-version = "4.0.5"
+version = "5.0.0"
 authors = ["Conrad Kleinespel <conradk@conradk.com>"]
 description = "Read passwords in console applications."
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Use `rpassword` within your code:
 extern crate rpassword;
 
 fn main() {
-    // Prompt for a password on TTY (safest but not default for backwards compatibility)
+    // Prompt for a password on TTY (safest but not always most practical when integrating with other tools or unit testing)
     let pass = rpassword::read_password_from_tty(Some("Password: ")).unwrap();
     println!("Your password is {}", pass);
     

--- a/README.md
+++ b/README.md
@@ -48,22 +48,6 @@ fn main() {
 
 The full API documentation is available at [https://docs.rs/rpassword](https://docs.rs/rpassword).
 
-## Optional feature
-
-The optional feature **enhanced_mock** can be enabled to change `read_password_with_reader` signature from 
-```
-pub fn read_password_with_reader<T>(source: Option<T>) -> ::std::io::Result<String>
-    where
-        T: ::std::io::BufRead
-```
-to
-```
-pub fn read_password_with_reader<T>(source: Option<&mut T>) -> ::std::io::Result<String>
-    where
-        T: ::std::io::BufRead
-```
-allowing to call `read_password_with_reader` multiple times with the same reader.
-
 ## Contributors
 
 We welcome contribution from everyone. Feel free to open an issue or a pull request at any time.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Here's a list of existing `rpassword` contributors:
 * [@DaveLancaster](https://github.com/DaveLancaster)
 * [@dcuddeback](https://github.com/dcuddeback)
 * [@Draphar](https://github.com/Draphar)
+* [@dvermd](https://github.com/dvermd)
 * [@equalsraf](https://github.com/equalsraf)
 * [@Heliozoa](https://github.com/Heliozoa)
 * [@JanLikar](https://github.com/JanLikar)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Here's a list of existing `rpassword` contributors:
 * [@JanLikar](https://github.com/JanLikar)
 * [@joshuef](https://github.com/joshuef)
 * [@longshorej](https://github.com/longshorej)
+* [@nicokoch](https://github.com/nicokoch)
 * [@petevine](https://github.com/petevine)
 * [@psych0d0g](https://github.com/psych0d0g)
 * [@retep998](https://github.com/retep998)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add `rpassword` as a dependency in Cargo.toml:
 
 ```toml
 [dependencies]
-rpassword = "4.0"
+rpassword = "5.0"
 ```
 
 Use `rpassword` within your code:
@@ -76,6 +76,7 @@ Here's a list of existing `rpassword` contributors:
 * [@dcuddeback](https://github.com/dcuddeback)
 * [@Draphar](https://github.com/Draphar)
 * [@equalsraf](https://github.com/equalsraf)
+* [@Heliozoa](https://github.com/Heliozoa)
 * [@JanLikar](https://github.com/JanLikar)
 * [@joshuef](https://github.com/joshuef)
 * [@longshorej](https://github.com/longshorej)

--- a/tests/no-terminal.rs
+++ b/tests/no-terminal.rs
@@ -45,18 +45,6 @@ fn mock_input_lf() -> Cursor<&'static [u8]> {
     Cursor::new(&b"A mocked response.\nAnother mocked response.\n"[..])
 }
 
-#[cfg(not(feature = "enhanced_mock"))]
-#[test]
-fn can_read_from_redirected_input() {
-    close_stdin();
-
-    let response = ::read_password_with_reader(Some(mock_input_crlf())).unwrap();
-    assert_eq!(response, "A mocked response.");
-    let response = ::read_password_with_reader(Some(mock_input_lf())).unwrap();
-    assert_eq!(response, "A mocked response.");
-}
-
-#[cfg(feature = "enhanced_mock")]
 #[test]
 fn can_read_from_redirected_input_many_times() {
     close_stdin();


### PR DESCRIPTION
**Release text**

The signature of `read_password_with_reader` has changed from:
```
pub fn read_password_with_reader<T>(source: Option<T>) -> ::std::io::Result<String>
    where
        T: ::std::io::BufRead
```
to
```
pub fn read_password_with_reader<T>(source: Option<&mut T>) -> ::std::io::Result<String>
    where
        T: ::std::io::BufRead
```

This allows to call `read_password_with_reader` multiple times with the same reader. Thanks @dvermd for this contribution!