### PR TITLE
Move unit tests to Github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: push
+
+jobs:
+  tests:
+    name: Run unit and integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        name: Install rust
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        name: Run cargo test
+        with:
+          command: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-os:
-  - linux
-  - osx
-rust:
-  - stable
-script:
-  - cargo build --example tests
-  - ./tests/tests-unix.sh

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Rustastic Password
 
-[![Build Status](https://travis-ci.org/conradkleinespel/rpassword.svg?branch=master)](https://travis-ci.org/conradkleinespel/rpassword)
+![CI](https://github.com/conradkleinespel/rpassword/workflows/CI/badge.svg)
 [![Build status](https://ci.appveyor.com/api/projects/status/h7ak407y28k0ufw2?svg=true)](https://ci.appveyor.com/project/conradkleinespel/rpassword)
-[![Chat on Discord](https://img.shields.io/badge/chat-on%20discord-7289DA)](https://discord.gg/9zXtYqQ)
 
 `rpassword` allows you to safely read passwords in a console application on Linux, OSX and Windows.
 

--- a/src/zero_on_drop.rs
+++ b/src/zero_on_drop.rs
@@ -1,14 +1,14 @@
-use std::{ops, mem, ptr, sync::atomic};
+use std::{mem, ops, ptr, sync::atomic};
 
 // Holds a string and zeros it when we're done.
 pub struct ZeroOnDrop {
-    inner: Inner
+    inner: Inner,
 }
 
 impl ZeroOnDrop {
     pub fn new() -> Self {
         ZeroOnDrop {
-            inner: Inner(String::new())
+            inner: Inner(String::new()),
         }
     }
 
@@ -52,4 +52,3 @@ impl Inner {
         atomic::compiler_fence(atomic::Ordering::SeqCst);
     }
 }
-


### PR DESCRIPTION
This will allow doing things like:

```rust
pub struct ReaderManager<'a, R: BufRead> {
    inner: &'a mut Box<R>,
}

impl<'a, R: BufRead> ReaderManager<'a, R> {
    pub fn new(inner: &'a mut Box<R>) -> ReaderManager<'a, R> {
        ReaderManager { inner }
    }

    pub fn read_line(&mut self) -> IoResult<String> {
        let mut s = String::new();
        self.inner.read_line(&mut s)?;
        Ok(s)
    }

    pub fn read_password(&mut self) -> IoResult<String> {
        hide_tty_input_during_callback(libc::STDIN_FILENO, || -> IoResult<String> {
            read_password_with_reader(Some(self.inner))
        })
    }
}
```

This means you can use any `BufRead` you want, including an existing `StdinLock` and still hide input if you need. Super useful if you want to swap out your input reader with a [`Cursor`](https://doc.rust-lang.org/std/io/struct.Cursor.html) in unit tests.