### PR TITLE
Added support for WASM

### DIFF
--- a/src/rpassword/all.rs
+++ b/src/rpassword/all.rs
@@ -3,7 +3,7 @@ use crate::rutil::print_tty::{print_tty, print_writer};
 use crate::rutil::safe_string::SafeString;
 use std::io::{BufRead, Write};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 mod wasm {
     use std::io::{self, BufRead};
 
@@ -26,7 +26,7 @@ mod wasm {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 mod unix {
     use libc::{c_int, tcsetattr, termios, ECHO, ECHONL, TCSANOW};
     use std::io::{self, BufRead};
@@ -108,7 +108,7 @@ mod unix {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use std::io::{self, BufReader};
     use std::io::{BufRead, StdinLock};
@@ -199,11 +199,11 @@ mod windows {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub use wasm::read_password;
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 pub use unix::read_password;
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 pub use windows::read_password;
 
 /// Reads a password from anything that implements BufRead

--- a/src/rutil/atty.rs
+++ b/src/rutil/atty.rs
@@ -27,7 +27,7 @@ pub enum Stream {
 }
 
 /// returns true if this is a tty
-#[cfg(all(unix, not(target_arch = "wasm32")))]
+#[cfg(target_family = "unix")]
 pub fn is(stream: Stream) -> bool {
     let fd = match stream {
         Stream::Stdout => libc::STDOUT_FILENO,
@@ -141,7 +141,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub fn is(_stream: Stream) -> bool {
     false
 }

--- a/src/rutil/print_tty.rs
+++ b/src/rutil/print_tty.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 mod wasm {
     use std::io::Write;
 
@@ -12,7 +12,7 @@ mod wasm {
 }
 
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 mod unix {
     use std::io::Write;
 
@@ -25,7 +25,7 @@ mod unix {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use std::io::Write;
     use std::os::windows::io::FromRawHandle;
@@ -66,9 +66,9 @@ pub fn print_writer(stream: &mut impl Write, prompt: impl ToString) -> std::io::
 }
 
 use std::io::Write;
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 pub use unix::print_tty;
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 pub use windows::print_tty;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub use wasm::print_tty;


### PR DESCRIPTION
It shows the input in clear text which is not ideal - need to add the TTY system calls to WASI for it to prevent the echo.
Will work on this next but for now this at least means it will compile on WASM targets