### PR TITLE
More improvements to rpassword for WASI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rpassword"
+name = "rpassword-wasi"
 version = "5.0.1"
 authors = ["Conrad Kleinespel <conradk@conradk.com>"]
 description = "Read passwords in console applications."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpassword-wasi"
-version = "5.0.1"
+version = "5.0.3"
 authors = ["Conrad Kleinespel <conradk@conradk.com>"]
 description = "Read passwords in console applications."
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,13 @@
 //!
 //! Here's how you can read a password:
 //! ```no_run
-//! let password = rpassword::read_password().unwrap();
+//! let password = rpassword_wasi::read_password().unwrap();
 //! println!("Your password is {}", password);
 //! ```
 //!
 //! You can also prompt for a password:
 //! ```no_run
-//! let password = rpassword::prompt_password("Your password: ").unwrap();
+//! let password = rpassword_wasi::prompt_password("Your password: ").unwrap();
 //! println!("Your password is {}", password);
 //! ```
 //!
@@ -19,12 +19,12 @@
 //! use std::io::Cursor;
 //!
 //! let mut mock_input = Cursor::new("my-password\n".as_bytes().to_owned());
-//! let password = rpassword::read_password_from_bufread(&mut mock_input).unwrap();
+//! let password = rpassword_wasi::read_password_from_bufread(&mut mock_input).unwrap();
 //! println!("Your password is {}", password);
 //!
 //! let mut mock_input = Cursor::new("my-password\n".as_bytes().to_owned());
 //! let mut mock_output = Cursor::new(Vec::new());
-//! let password = rpassword::prompt_password_from_bufread(&mut mock_input, &mut mock_output, "Your password: ").unwrap();
+//! let password = rpassword_wasi::prompt_password_from_bufread(&mut mock_input, &mut mock_output, "Your password: ").unwrap();
 //! println!("Your password is {}", password);
 //! ```
 

--- a/src/rpassword/all.rs
+++ b/src/rpassword/all.rs
@@ -3,8 +3,8 @@ use crate::rutil::print_tty::{print_tty, print_writer};
 use crate::rutil::safe_string::SafeString;
 use std::io::{BufRead, Write};
 
-#[cfg(target_family = "wasm")]
-mod wasm {
+#[cfg(target_os = "wasi")]
+mod wasi {
     use std::io::{self, BufRead};
 
     /// Reads a password from the TTY
@@ -199,8 +199,8 @@ mod windows {
     }
 }
 
-#[cfg(target_family = "wasm")]
-pub use wasm::read_password;
+#[cfg(target_os = "wasi")]
+pub use wasi::read_password;
 #[cfg(target_family = "unix")]
 pub use unix::read_password;
 #[cfg(target_family = "windows")]
@@ -226,7 +226,11 @@ pub fn prompt_password_from_bufread(
 
 /// Prompts on the TTY and then reads a password from stdin
 pub fn prompt_password(prompt: impl ToString) -> std::io::Result<String> {
-    print_tty(prompt.to_string().as_str()).and_then(|_| read_password())
+    let ret = print_tty(prompt.to_string().as_str())
+        .and_then(|_| read_password());
+    #[cfg(target_os = "wasi")]
+    let _ = print_tty("\n");
+    ret
 }
 
 #[cfg(test)]

--- a/src/rpassword/all.rs
+++ b/src/rpassword/all.rs
@@ -3,7 +3,7 @@ use crate::rutil::print_tty::{print_tty, print_writer};
 use crate::rutil::safe_string::SafeString;
 use std::io::{BufRead, Write};
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 mod wasm {
     use std::io::{self, BufRead};
 
@@ -26,7 +26,7 @@ mod wasm {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 mod unix {
     use libc::{c_int, tcsetattr, termios, ECHO, ECHONL, TCSANOW};
     use std::io::{self, BufRead};
@@ -108,7 +108,7 @@ mod unix {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use std::io::{self, BufReader};
     use std::io::{BufRead, StdinLock};
@@ -199,11 +199,11 @@ mod windows {
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub use wasm::read_password;
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 pub use unix::read_password;
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 pub use windows::read_password;
 
 /// Reads a password from anything that implements BufRead

--- a/src/rutil/atty.rs
+++ b/src/rutil/atty.rs
@@ -27,7 +27,7 @@ pub enum Stream {
 }
 
 /// returns true if this is a tty
-#[cfg(all(unix, not(target_arch = "wasm32")))]
+#[cfg(target_family = "unix")]
 pub fn is(stream: Stream) -> bool {
     let fd = match stream {
         Stream::Stdout => libc::STDOUT_FILENO,
@@ -141,7 +141,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub fn is(_stream: Stream) -> bool {
     false
 }

--- a/src/rutil/atty.rs
+++ b/src/rutil/atty.rs
@@ -141,7 +141,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(target_family = "wasm")]
+#[cfg(target_os = "wasi")]
 pub fn is(_stream: Stream) -> bool {
     false
 }

--- a/src/rutil/print_tty.rs
+++ b/src/rutil/print_tty.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 mod wasm {
     use std::io::Write;
 
@@ -12,7 +12,7 @@ mod wasm {
 }
 
 
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 mod unix {
     use std::io::Write;
 
@@ -25,7 +25,7 @@ mod unix {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use std::io::Write;
     use std::os::windows::io::FromRawHandle;
@@ -66,9 +66,9 @@ pub fn print_writer(stream: &mut impl Write, prompt: impl ToString) -> std::io::
 }
 
 use std::io::Write;
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 pub use unix::print_tty;
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 pub use windows::print_tty;
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub use wasm::print_tty;

--- a/src/rutil/print_tty.rs
+++ b/src/rutil/print_tty.rs
@@ -1,3 +1,17 @@
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use std::io::Write;
+
+    /// Displays a message on the STDOUT
+    pub fn print_tty(prompt: impl ToString) -> std::io::Result<()> {
+        let mut stdout = std::io::stdout();
+        write!(stdout, "{}", prompt.to_string().as_str())?;
+        stdout.flush()?;
+        Ok(())
+    }
+}
+
+
 #[cfg(unix)]
 mod unix {
     use std::io::Write;
@@ -56,3 +70,5 @@ use std::io::Write;
 pub use unix::print_tty;
 #[cfg(windows)]
 pub use windows::print_tty;
+#[cfg(target_arch = "wasm32")]
+pub use wasm::print_tty;

--- a/src/rutil/print_tty.rs
+++ b/src/rutil/print_tty.rs
@@ -1,13 +1,13 @@
-#[cfg(target_family = "wasm")]
-mod wasm {
+#[cfg(target_os = "wasi")]
+mod wasi {
     use std::io::Write;
 
     /// Displays a message on the STDOUT
     pub fn print_tty(prompt: impl ToString) -> std::io::Result<()> {
-        let mut stdout = std::io::stdout();
-        write!(stdout, "{}", prompt.to_string().as_str())?;
-        stdout.flush()?;
-        Ok(())
+        let mut stream = std::fs::OpenOptions::new().write(true).open("/dev/tty")?;
+        stream
+            .write_all(prompt.to_string().as_str().as_bytes())
+            .and_then(|_| stream.flush())
     }
 }
 
@@ -70,5 +70,5 @@ use std::io::Write;
 pub use unix::print_tty;
 #[cfg(target_family = "windows")]
 pub use windows::print_tty;
-#[cfg(target_family = "wasm")]
-pub use wasm::print_tty;
+#[cfg(target_os = "wasi")]
+pub use wasi::print_tty;

--- a/tests/no-terminal.rs
+++ b/tests/no-terminal.rs
@@ -3,7 +3,7 @@
 
 use std::io::Cursor;
 
-use rpassword::read_password_from_bufread;
+use rpassword_wasi::read_password_from_bufread;
 
 #[cfg(unix)]
 #[cfg(unix)]


### PR DESCRIPTION
- Made the changes you recommended which was to be consistent and use /dev/tty for both the reading and writing.
- Added a missing line feed that wasnt appearing on the console (default behaviour for other environments)
- Narrowed the build down to just WASI for now - emscripten should be covered by the UNIX build anyway