### PR TITLE
Fix a bug where the newline was not added on windows

### DIFF
--- a/src/rpassword/all.rs
+++ b/src/rpassword/all.rs
@@ -188,10 +188,12 @@ mod windows {
 
         let hidden_input = HiddenInput::new(handle)?;
 
-        reader.read_line(&mut password)?;
+        let r = reader.read_line(&mut password);
 
         // Newline for windows which otherwise prints on the same line.
         println!();
+
+        if r.is_err() { return Err(r.unwrap_err()) }
 
         std::mem::drop(hidden_input);
 


### PR DESCRIPTION
When a user enter a password, if any io error occurs on the reader when reading a line, the new line is not added, and print! or println! will print on the same line.