### PR TITLE
Replace winapi with windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.60"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["std", "winnt", "fileapi", "processenv", "winbase", "handleapi", "consoleapi", "minwindef", "wincon"] }
+windows-sys = { version = "0.42.0", features = ["Win32_Foundation", "Win32_System_Console", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_SystemServices"] }
 
 [dependencies]
 rtoolbox = { path = "../rtoolbox", version = "0.0" }

--- a/tests/no-terminal.rs
+++ b/tests/no-terminal.rs
@@ -6,7 +6,6 @@ use std::io::Cursor;
 use rpassword::read_password_from_bufread;
 
 #[cfg(unix)]
-#[cfg(unix)]
 fn close_stdin() {
     unsafe {
         libc::close(libc::STDIN_FILENO);
@@ -14,11 +13,9 @@ fn close_stdin() {
 }
 
 #[cfg(windows)]
-#[cfg(windows)]
 fn close_stdin() {
-    use winapi::um::handleapi::CloseHandle;
-    use winapi::um::processenv::GetStdHandle;
-    use winapi::um::winbase::STD_INPUT_HANDLE;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Console::{GetStdHandle, STD_INPUT_HANDLE};
 
     unsafe {
         CloseHandle(GetStdHandle(STD_INPUT_HANDLE));


### PR DESCRIPTION
The Rust ecosystem is migrating from winapi to windows-sys, for example https://github.com/tokio-rs/tokio/pull/5204