### PR TITLE
Restrict errno to linux

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -22,6 +22,8 @@ fn io_result(ret: c_int) -> std::io::Result<()> {
 fn is_interactive_terminal(fd: c_int) -> bool {
     let result = unsafe { isatty(fd) != 0 };
     // For any non terminal, `isatty` produces ENOTTY, we clean it up
+    // Note: errno clearing is only supported on Linux via __errno_location()
+    #[cfg(target_os = "linux")]
     unsafe {
         *libc::__errno_location() = 0;
     };


### PR DESCRIPTION
I was having a problem updating my app to the latest release, and bisected the problem back to 148d989b02adfc44bddcde96d05202cbaafd4619. Copilot suggested this approach which seems to work ok for me locally.