### PR TITLE
fix(unix): use correct errno accessor on apple platforms

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -19,12 +19,26 @@ fn io_result(ret: c_int) -> std::io::Result<()> {
     }
 }
 
+#[cfg(target_vendor = "apple")]
+fn errno_location() -> *mut c_int {
+    unsafe { libc::__error() }
+}
+
+#[cfg(not(target_vendor = "apple"))]
+fn errno_location() -> *mut c_int {
+    unsafe { libc::__errno_location() }
+}
+
+fn clear_errno() {
+    unsafe {
+        *errno_location() = 0;
+    }
+}
+
 fn is_interactive_terminal(fd: c_int) -> bool {
     let result = unsafe { isatty(fd) != 0 };
     // For any non terminal, `isatty` produces ENOTTY, we clean it up
-    unsafe {
-        *libc::__errno_location() = 0;
-    };
+    clear_errno();
     result
 }
 


### PR DESCRIPTION
# macOS errno build fix

## Problem

`rpassword 7.5.0` used Linux-only `libc::__errno_location()` in Unix code:

```text
cannot find function `__errno_location` in crate `libc`
```

On macOS, libc exposes errno through `libc::__error()` instead.

## Fix

Use the correct errno accessor per platform:

- Apple platforms: `libc::__error()`
- Other Unix platforms: `libc::__errno_location()`

This keeps the original behavior while allowing macOS builds to compile.
